### PR TITLE
Add mac flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 use nix
-use flake .\#
+use flake .\#devShells.aarch64-darwin

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
 
       - name: Run `nix build` static
-        run: nix build
+        run: nix build .#packages.x86_64-linux.hpci
 
       # - name: Authenticate to google cloud
       #   uses: google-github-actions/auth@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,8 +1,6 @@
 name: Push to GCP Artifact Registry
 on:
   push:
-    branches:
-      - test
 
 jobs:
   # tests:

--- a/README.md
+++ b/README.md
@@ -3,3 +3,40 @@
 [![hpci on Stackage Nightly](https://stackage.org/package/hpci/badge/nightly)](https://stackage.org/nightly/package/hpci)
 
 Generated with [template-haskell](https://github.com/jonascarpay/template-haskell)
+
+## Development environment
+
+### If you use `nix`:
+
+This project uses [nix](https://nixos.org/) and [nix flakes](https://nixos.wiki/wiki/flakes) to provide a consistent software environment for development and compilation.
+To get started with `nix` I recommend using the [Determinante Systems nix installer](https://github.com/DeterminateSystems/nix-installer), and the [Zero to Nix](https://zero-to-nix.com/) guide to learning Nix and flakes.
+There is also a `.envrc` file (requires installing [direnv](https://direnv.net/) and [nix-direnv](https://github.com/nix-community/nix-direnv)) to automatically start a nix flake devShell when you `cd` into the directory containing the code from this repo.
+The flake uses `cabal2nix` to generate nix build instructions from the Cabal file, therefore new haskell dependencies can be added via cabal, with no need to adjust the `flake.nix`.
+
+The `flake.nix` file is configured to work for both x86_64-linux and aarch-darwin architecture + operating systems, however the set up is slightly different between them:
+  - the x86_64-linux development environment uses a version of GHC that has been compiled against `musl` rather than `glibc`.
+    - This allows generation of a statically linked Haskell executable (see [this blog post for more details](https://cs-syd.eu/posts/2024-04-20-static-linking-haskell-nix)).
+    - I am not currently using linux for my day-to-day development on this project, rather I am using this exclusively for generating portable executables.
+  
+  - the aarch64-darwin development environment does not use musl-linked packages.
+
+If you do not set up `direnv` (see links above), use `nix develop .#devShells.x86_64-linux` or `nix develop .#devShells.aarch64-darwin` depending on your architecture + operating system.
+
+To build a statically linked executable on x86_64-linux use `nix build .#packages.x86_64-linux.hpci`.
+
+To build a dynamically linked executable on aarch64-darwin use `cabal build` inside the flake devShell.
+
+### If you do not use `nix`:
+
+You do not need nix to run the code, all you need is the Glascow Haskell Compiler (GHC) and Cabal package manager.
+These can been downloaded using [GHCup](https://www.haskell.org/ghcup/).
+
+To compile and run the program, use `cabal run exes --` followed by the following required arguments:
+  - username   - *username on remote system*
+  - hostname   - *IP address or domain name or remote host*
+  - port       - *port declaration - typically 22*
+  - cmd        - *command to execute on remote system - typically `qsub` on PBS hpci*
+  - publickey  - *local filepath for ssh public key*
+  - privatekey - *local filepath for ssh private key*
+  - script     - *local filepath of `.pbs` script to accomany the `qsub` command*
+  - logFile    - *remote filepath of logfile produced by `.pbs` script to copy back to local system*

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719332714,
-        "narHash": "sha256-XORSHyBUoQzJLCThqm34Bnw03Ocleg9bGUfRHNO7iqQ=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "044299a26505c304cfbbd489080c0f2176de2ccb",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,54 +3,77 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let pkgs = nixpkgs.legacyPackages.${system}.pkgsMusl;
-            static_ssl = (pkgs.openssl.override { static = true;});
-            haskellPackages = pkgs.haskell.packages.ghc948;
-            packageName = "hpci";
-            jailbreakUnbreak = pkg: pkgs.haskell.lib.doJailbreak (pkg.overrideAttrs (_: { meta = { }; }));
-            inherit (pkgs.haskell.lib) appendConfigureFlags justStaticExecutables;
-            mypackage = haskellPackages.callCabal2nix packageName self rec {
+  outputs = { self, nixpkgs }:
+    let
+      pkgsForSystem = system: if system == "x86_64-linux" then
+        nixpkgs.legacyPackages.${system}.pkgsMusl
+      else
+        nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages =
+        let
+          packageForSystem = system:
+            let
+              pkgs = pkgsForSystem system;
+              static_ssl = (pkgs.openssl.override { static = true; });
+              haskellPackages = pkgs.haskell.packages.ghc948;
+              packageName = "hpci";
+              jailbreakUnbreak = pkg: pkgs.haskell.lib.doJailbreak (pkg.overrideAttrs (_: { meta = { }; }));
+              inherit (pkgs.haskell.lib) appendConfigureFlags justStaticExecutables;
+              mypackage = haskellPackages.callCabal2nix packageName self rec {
+              };
+            in
+            pkgs.haskell.lib.overrideCabal mypackage (old: {
+              enableSharedExecutables = false;
+              enableSharedLibraries = false;
+              configureFlags = [
+                "--ghc-option=-optl=-static"
+                "--ghc-option=-optl=-L${pkgs.zlib.static}/lib"
+                "--ghc-option=-optl=-lz"
+                "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"
+                "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+                "--extra-lib-dirs=${pkgs.libssh2.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+                "--extra-lib-dirs=${pkgs.pkg-config}/lib"
+                "--extra-lib-dirs=${static_ssl}/lib"
+                "--extra-lib-dirs=${pkgs.zlib.static}/lib"
+              ];
+              buildDepends = [
+                pkgs.libffi
+                pkgs.libssh2
+                pkgs.pkg-config
+                static_ssl
+                pkgs.zlib.static
+              ];
+            });
+        in
+        {
+          x86_64-linux = { hpci = packageForSystem "x86_64-linux"; };
+          aarch64-darwin = { hpci = packageForSystem "aarch64-darwin"; };
+        };
+
+      devShells =
+        let
+          devShellForSystem = system:
+            let pkgs = pkgsForSystem system;
+                haskellPackages = pkgs.haskell.packages.ghc948;
+            in pkgs.mkShell {
+              buildInputs = with haskellPackages; [
+                haskell-language-server
+                cabal-install
+                cabal2nix
+              ] ++ [ pkgs.zlib ];
+              inputsFrom = builtins.attrValues self.packages.${system};
             };
         in
         {
-          packages.${packageName} = pkgs.haskell.lib.overrideCabal mypackage (old: {
-            enableSharedExecutables = false;
-            enableSharedLibraries = false;
-            configureFlags =     [
-                  "--ghc-option=-optl=-static"
-                  "--ghc-option=-optl=-L${pkgs.zlib.static}/lib"
-                  "--ghc-option=-optl=-lz"
-                  "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"
-                  "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
-                  "--extra-lib-dirs=${pkgs.libssh2.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
-                  "--extra-lib-dirs=${pkgs.pkg-config}/lib"
-                  "--extra-lib-dirs=${static_ssl}/lib"
-                  "--extra-lib-dirs=${pkgs.zlib.static}/lib"
-            ];
-            buildDepends = [
-              pkgs.libffi
-              pkgs.libssh2
-              pkgs.pkg-config
-              static_ssl
-              pkgs.zlib.static
-            ];
-          });
+          x86_64-linux = devShellForSystem "x86_64-linux";
+          aarch64-darwin = devShellForSystem "aarch64-darwin";
+        };
 
-          defaultPackage = self.packages.${system}.${packageName};
-          devShell = pkgs.mkShell {
-            buildInputs = with haskellPackages; [
-              haskell-language-server
-              cabal-install
-              cabal2nix
-            ] ++ [ pkgs.zlib ];
-            inputsFrom = builtins.attrValues self.packages.${system};
-          };
-        }
-      );
+      defaultPackage.x86_64-linux = self.packages.x86_64-linux.hpci;
+      defaultPackage.aarch64-darwin = self.packages.aarch64-darwin.hpci;
+    };
 }


### PR DESCRIPTION
This adjusts the nix flake to support fully static linking on x86_64-linux machines using ghc compiled with Musl version of libc ([see here for a description](https://cs-syd.eu/posts/2024-04-20-static-linking-haskell-nix)).

Also adds README details for compilation, setting up dev environment and running the software.