### PR TITLE
Feature/bccatlas 18 add integration test

### DIFF
--- a/.github/workflows/build-pbs.yml
+++ b/.github/workflows/build-pbs.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "ci/**"
       - ".github/workflows/build-pbs.yml"
+  pull_request:
+    paths:
+      - "ci/**"
+      - ".github/workflows/build-pbs.yml"
 
 env:
   LOCATION: australia-southeast1

--- a/.github/workflows/build-pbs.yml
+++ b/.github/workflows/build-pbs.yml
@@ -20,6 +20,7 @@ jobs:
       contents: "read"
       id-token: "write"
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-pbs.yml
+++ b/.github/workflows/build-pbs.yml
@@ -1,0 +1,55 @@
+name: Build and push PBS docker image
+
+# Only run if there have been changes to code in `ci` directory
+on:
+  push:
+    paths:
+      - "ci/**"
+      - ".github/workflows/build-pbs.yml"
+  pull_request:
+    paths:
+      - "ci/**"
+      - ".github/workflows/build-pbs.yml"
+
+env:
+  LOCATION: australia-southeast1
+
+jobs:
+  build-and-push-pbs-docker:
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: authenticate to google cloud
+        id: "auth"
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: "true"
+          service_account: "grunner-ci-sa@${{secrets.PROJECT_ID}}.iam.gserviceaccount.com"
+          workload_identity_provider: "projects/${{secrets.PROJECT_NUMBER}}/locations/global/workloadIdentityPools/${{secrets.PROJECT_ID}}-workload-id-pool/providers/github-provider"
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: latest
+
+      - name: Docker auth
+        run: gcloud auth configure-docker ${{env.LOCATION}}-docker.pkg.dev
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Use latest tag, as this is just for PBS used for testing
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-pbs.yml
+++ b/.github/workflows/build-pbs.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - "ci/**"
       - ".github/workflows/build-pbs.yml"
-  pull_request:
-    paths:
-      - "ci/**"
-      - ".github/workflows/build-pbs.yml"
 
 env:
   LOCATION: australia-southeast1
@@ -47,8 +43,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: Dockerfile
+          context: ci/
+          file: ci/Dockerfile
           push: true
           tags: ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest
           cache-from: type=gha

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,10 +13,7 @@ env:
   LOCATION: australia-southeast1
 
 jobs:
-  # tests:
-  #   uses: ./.github/workflows/test.yaml
   push_to_registry:
-    # needs: [tests]
     permissions:
       contents: "read"
       id-token: "write"
@@ -92,13 +89,3 @@ jobs:
           docker stop pbs
           docker image prune -f
           rm test_key*
-
-      # - name: Push to GCP Artifact Registry
-      #   if: ${{steps.test-docker.outputs.IMAGE_EXISTS == 'FALSE' }}
-      #   run: |
-      #     gcloud artifacts generic upload \
-      #       --location=australia-southeast1 \
-      #       --source=./result/bin/hpci-exe \
-      #       --package=hpci \
-      #       --version=0.0.1 \
-      #       --repository=generic

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,4 +1,4 @@
-name: Push to GCP Artifact Registry
+name: Build and test hcpi binary
 on:
   push:
     paths-ignore:
@@ -13,7 +13,7 @@ env:
   LOCATION: australia-southeast1
 
 jobs:
-  push_to_registry:
+  build-and-test-hcpi:
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,6 +18,7 @@ jobs:
       contents: "read"
       id-token: "write"
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,15 +77,8 @@ jobs:
 
       - name: Run test
         run: |
-          result/bin/hpci-exe \
-            pbsuser \
-            localhost \
-            2222 \
-            qsub \
-            test_key.pub \
-            test_key \
-            ci/test_job.pbs \
-            test_job.log
+          ls
+          result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
           cat test_job.log
 
       - name: Clean up

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,6 +1,16 @@
 name: Push to GCP Artifact Registry
 on:
   push:
+    paths-ignore:
+      - "ci/**"
+      - ".github/workflows/build-pbs.yml"
+  pull_request:
+    paths-ignore:
+      - "ci/**"
+      - ".github/workflows/build-pbs.yml"
+
+env:
+  LOCATION: australia-southeast1
 
 jobs:
   # tests:
@@ -20,17 +30,58 @@ jobs:
       - name: Run `nix build` static
         run: nix build .#packages.x86_64-linux.hpci
 
-      # - name: Authenticate to google cloud
-      #   uses: google-github-actions/auth@v2
-      #   with:
-      #     create_credentials_file: "true"
-      #     service_account: "grunner-ci-sa@${{secrets.PROJECT_ID}}.iam.gserviceaccount.com"
-      #     workload_identity_provider: "projects/${{secrets.PROJECT_NUMBER}}/locations/global/workloadIdentityPools/${{secrets.PROJECT_ID}}-workload-id-pool/providers/github-provider"
+      - name: Authenticate to google cloud
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: "true"
+          service_account: "grunner-ci-sa@${{secrets.PROJECT_ID}}.iam.gserviceaccount.com"
+          workload_identity_provider: "projects/${{secrets.PROJECT_NUMBER}}/locations/global/workloadIdentityPools/${{secrets.PROJECT_ID}}-workload-id-pool/providers/github-provider"
 
-      # - name: Set up gcloud SDK
-      #   uses: google-github-actions/setup-gcloud@v2
-      #   with:
-      #     version: latest
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: latest
+
+      - name: Docker auth
+        run: gcloud auth configure-docker ${{env.LOCATION}}-docker.pkg.dev
+
+      - name: Pull Docker image
+        run: docker pull ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest
+
+      - name: Start Dockerised PBS
+        run: |
+          docker run \
+            -d --rm \
+            -p 2222:22 \
+            --name pbs \
+            -h pbs_container \
+            -v ${{secrets.TEST_KEY_PUB}}:/tmp/.ssh/authorized_keys:ro \
+            ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
+            /bin/bash -l /run.sh
+          while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 2 ]
+          do
+            echo "Waiting for PBS node to become available";
+            sleep 2
+          done
+          echo "PBS properly configured"
+
+      - name: Run test
+        run: |
+          result/bin/hpci-exe \
+            pbsuser \
+            localhost \
+            2222 \
+            qsub \
+            ${{secrets.TEST_KEY_PUB}} \
+            ${{secrets.TEST_KEY}} \
+            ci/test_job.pbs \
+            test_job.log
+          cat test_job.log
+
+      - name: Clean up Docker images
+        run: |
+          docker stop pbs
+          docker image prune -f
 
       # - name: Push to GCP Artifact Registry
       #   if: ${{steps.test-docker.outputs.IMAGE_EXISTS == 'FALSE' }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -59,12 +59,15 @@ jobs:
 
       - name: Start Dockerised PBS
         run: |
+          wc test_key.pub
+          wc test_key
+          ls -la
           docker run \
             -d --rm \
             -p 2222:22 \
             --name pbs \
             -h pbs_container \
-            -v test_key.pub:/tmp/authorized_keys \
+            --mount type=bind,source=$(pwd)/test_key.pub,target=/tmp/authorized_keys \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
             bash /run.sh
           while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 1 ]
@@ -77,7 +80,7 @@ jobs:
 
       - name: Run test
         run: |
-          docker exec -u pbsuser pbs ls -l /home/pbsuser/.ssh/authorized_keys
+          docker exec -u pbsuser pbs ls -l /home/pbsuser/.ssh
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
 
       - name: Clean up

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -63,11 +63,12 @@ jobs:
             -h pbs_container \
             -v test_key.pub:/tmp/.ssh/authorized_keys:ro \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
-            /bin/bash -l /run.sh
+            bash /run.sh
           while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 2 ]
           do
             echo "Waiting for PBS node to become available";
-            sleep 2
+            docker logs pbs
+            sleep 5
           done
           echo "PBS properly configured"
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run test
         run: |
-          ls
+          docker exec -u pbsuser cat /home/pbsuser/.ssh/authorized_keys
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
           cat test_job.log
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -55,6 +55,7 @@ jobs:
         run: |
           echo "$TEST_KEY_PUB" > test_key.pub
           echo "$TEST_KEY" > test_key
+          chmod 600 test_key*
 
       - name: Start Dockerised PBS
         run: |
@@ -63,7 +64,7 @@ jobs:
             -p 2222:22 \
             --name pbs \
             -h pbs_container \
-            -v test_key.pub:/tmp/.ssh/authorized_keys:ro \
+            -v test_key.pub:/tmp/authorized_keys:ro \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
             bash /run.sh
           while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 1 ]
@@ -76,7 +77,6 @@ jobs:
 
       - name: Run test
         run: |
-          chmod 600 test_key*
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
 
       - name: Clean up

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -64,7 +64,7 @@ jobs:
             -p 2222:22 \
             --name pbs \
             -h pbs_container \
-            -v test_key.pub:/tmp/authorized_keys:ro \
+            -v test_key.pub:/tmp/authorized_keys \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
             bash /run.sh
           while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 1 ]

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -76,9 +76,8 @@ jobs:
 
       - name: Run test
         run: |
-          docker exec -u pbsuser pbs cat /home/pbsuser/.ssh/authorized_keys
+          chmod 600 test_key*
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
-          cat test_job.log
 
       - name: Clean up
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -49,9 +49,12 @@ jobs:
         run: docker pull ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest
 
       - name: Load test keys on runner
+        env:
+          TEST_KEY_PUB: ${{secrets.TEST_KEY_PUB}}
+          TEST_KEY: ${{secrets.TEST_KEY}}
         run: |
-          echo "${{secrets.TEST_KEY_PUB}}" > test_key.pub
-          echo "${{secrets.TEST_KEY}}" > test_key
+          echo "$TEST_KEY_PUB" > test_key.pub
+          echo "$TEST_KEY" > test_key
           chmod 600 test_key*
 
       - name: Start Dockerised PBS

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -76,7 +76,16 @@ jobs:
           echo "PBS properly configured"
 
       - name: Run test
-        run: result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
+        run: |
+          result/bin/hpci-exe \
+            pbsuser \
+            localhost \
+            2222 \
+            /opt/pbs/bin/qsub \
+            test_key.pub \
+            test_key \
+            ci/test_job.pbs \
+            test_job.log
 
       - name: Clean up
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -64,10 +64,10 @@ jobs:
             -v test_key.pub:/tmp/.ssh/authorized_keys:ro \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
             bash /run.sh
-          while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 2 ]
+          while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 1 ]
           do
             echo "Waiting for PBS node to become available";
-            docker logs pbs
+            docker logs --tail 1 pbs
             sleep 5
           done
           echo "PBS properly configured"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -48,6 +48,12 @@ jobs:
       - name: Pull Docker image
         run: docker pull ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest
 
+      - name: Load test keys on runner
+        run: |
+          cat ${{secrets.TEST_KEY_PUB}} > test_key.pub
+          cat ${{secrets.TEST_KEY}} > test_key
+          chmod 600 test_key*
+
       - name: Start Dockerised PBS
         run: |
           docker run \
@@ -55,7 +61,7 @@ jobs:
             -p 2222:22 \
             --name pbs \
             -h pbs_container \
-            -v ${{secrets.TEST_KEY_PUB}}:/tmp/.ssh/authorized_keys:ro \
+            -v test_key.pub:/tmp/.ssh/authorized_keys:ro \
             ${{env.LOCATION}}-docker.pkg.dev/${{secrets.PROJECT_ID}}/docker/pbs:latest \
             /bin/bash -l /run.sh
           while [ `docker exec -u pbsuser pbs pbsnodes -a | grep "Mom = pbs_container" | wc -l` -ne 2 ]
@@ -72,16 +78,17 @@ jobs:
             localhost \
             2222 \
             qsub \
-            ${{secrets.TEST_KEY_PUB}} \
-            ${{secrets.TEST_KEY}} \
+            test_key.pub \
+            test_key \
             ci/test_job.pbs \
             test_job.log
           cat test_job.log
 
-      - name: Clean up Docker images
+      - name: Clean up
         run: |
           docker stop pbs
           docker image prune -f
+          rm test_key*
 
       # - name: Push to GCP Artifact Registry
       #   if: ${{steps.test-docker.outputs.IMAGE_EXISTS == 'FALSE' }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -55,7 +55,6 @@ jobs:
         run: |
           echo "$TEST_KEY_PUB" > test_key.pub
           echo "$TEST_KEY" > test_key
-          chmod 600 test_key*
 
       - name: Start Dockerised PBS
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Load test keys on runner
         run: |
-          'echo "${{secrets.TEST_KEY_PUB}}" > test_key.pub'
-          'echo "${{secrets.TEST_KEY}}" > test_key'
+          echo "${{secrets.TEST_KEY_PUB}}" > test_key.pub
+          echo "${{secrets.TEST_KEY}}" > test_key
           chmod 600 test_key*
 
       - name: Start Dockerised PBS

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -59,9 +59,6 @@ jobs:
 
       - name: Start Dockerised PBS
         run: |
-          wc test_key.pub
-          wc test_key
-          ls -la
           docker run \
             -d --rm \
             -p 2222:22 \
@@ -79,9 +76,7 @@ jobs:
           echo "PBS properly configured"
 
       - name: Run test
-        run: |
-          docker exec -u pbsuser pbs ls -l /home/pbsuser/.ssh
-          result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
+        run: result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
 
       - name: Clean up
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run test
         run: |
-          docker exec -u pbsuser pbs wc /home/pbsuser/.ssh/authorized_keys
+          docker exec -u pbsuser pbs ls -l /home/pbsuser/.ssh/authorized_keys
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
 
       - name: Clean up

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Run test
         run: |
+          docker exec -u pbsuser pbs wc /home/pbsuser/.ssh/authorized_keys
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
 
       - name: Clean up

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Load test keys on runner
         run: |
-          cat ${{secrets.TEST_KEY_PUB}} > test_key.pub
-          cat ${{secrets.TEST_KEY}} > test_key
+          'echo "${{secrets.TEST_KEY_PUB}}" > test_key.pub'
+          'echo "${{secrets.TEST_KEY}}" > test_key'
           chmod 600 test_key*
 
       - name: Start Dockerised PBS

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run test
         run: |
-          docker exec -u pbsuser cat /home/pbsuser/.ssh/authorized_keys
+          docker exec -u pbsuser pbs cat /home/pbsuser/.ssh/authorized_keys
           result/bin/hpci-exe pbsuser localhost 2222 qsub test_key.pub test_key ci/test_job.pbs test_job.log
           cat test_job.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 ### hpci ###
-*.pbs
 *.log
 
 ### Nix ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### hpci ###
 *.log
+ci/test_key*
 
 ### Nix ###
 result

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The `makefile` has convenience commands for local testing.
 A summary of commands can be accessed using `make help`.
 
 For typical development and testing on an aarch64-darwin machine run:
+- ` gcloud auth login --project [GCP_PROJECT_NAME]`
+- ` gcloud auth configure-docker [GCP_REGION]-docker.pkg.dev/[GCP_PROJECT_NAME]/docker`
 - `make PROJECT=[GCP_PROJECT_NAME] pull` to pull docker image
 - `make PROJECT=[GCP_PROJECT_NAME] run` to run OpenPBS docker container
 - In a seperate terminal run `ls app/*.hs | entr make test` to recompile and run tests eachtime `hpci` haskell files are saved (requires installing [entr](https://github.com/eradman/entr))

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The code for building the docker image (and associated scripts) are in the `ci` 
 It is tricky to build this image on aarch64-darwin as building the docker image involves compiling OpenPBS from source.
 
 The `.github/workflows/build-pbs.yml` workflow file builds the image in ci (only if there has been a change to code in the `ci` directory, or the `build-pbs.yml` workflow file) and pushes the image to a GCP artifact registry.
-The `.github/workflows/push.yml` builds a fully statically linked version of `hpci`, pulls the test docker image, and runs the new `hpci` binary to connect to the OpenPBS docker container and run a basic job submission.
+The `.github/workflows/build-test.yml` builds a fully statically linked version of `hpci`, pulls the test docker image, and runs the new `hpci` binary to connect to the OpenPBS docker container and run a basic job submission.
 
 ## Testing locally
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `flake.nix` file is configured to work for both x86_64-linux and aarch-darwi
   
   - the aarch64-darwin development environment does not use musl-linked packages.
 
-If you do not set up `direnv` (see links above), use `nix develop .#devShells.x86_64-linux` or `nix develop .#devShells.aarch64-darwin` depending on your architecture + operating system.
+If you do not set up `direnv` (see links above), activate a nix development environment using `nix develop .#devShells.x86_64-linux` or `nix develop .#devShells.aarch64-darwin` depending on your architecture + operating system.
 
 To build a statically linked executable on x86_64-linux use `nix build .#packages.x86_64-linux.hpci`.
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ To compile and run the program, use `cabal run exes --` followed by the followin
   - privatekey - *local filepath for ssh private key*
   - script     - *local filepath of `.pbs` script to accomany the `qsub` command*
   - logFile    - *remote filepath of logfile produced by `.pbs` script to copy back to local system*
+
+## Testing
+
+Integration tests are run against a version of OpenPBS dockerised along with an openssh server.
+The code for building the docker image (and associated scripts) are in the `ci` directory.
+It is tricky to build this image on aarch64-darwin as building the docker image involves compiling OpenPBS from source.
+The `.github/workflows/build-pbs.yml` workflow file builds the image in ci (only if there has been a change to code in the `ci` directory, or the `build-pbs.yml` workflow file) and pushes the image to a GCP artifact registry.
+
+The `makefile` also has convenience commands for building the image locally, running a container and interacting with it.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,22 @@ To compile and run the program, use `cabal run exes --` followed by the followin
   - script     - *local filepath of `.pbs` script to accomany the `qsub` command*
   - logFile    - *remote filepath of logfile produced by `.pbs` script to copy back to local system*
 
-## Testing
+## Testing in CI
 
 Integration tests are run against a version of OpenPBS dockerised along with an openssh server.
 The code for building the docker image (and associated scripts) are in the `ci` directory.
 It is tricky to build this image on aarch64-darwin as building the docker image involves compiling OpenPBS from source.
-The `.github/workflows/build-pbs.yml` workflow file builds the image in ci (only if there has been a change to code in the `ci` directory, or the `build-pbs.yml` workflow file) and pushes the image to a GCP artifact registry.
 
-The `makefile` also has convenience commands for building the image locally, running a container and interacting with it.
+The `.github/workflows/build-pbs.yml` workflow file builds the image in ci (only if there has been a change to code in the `ci` directory, or the `build-pbs.yml` workflow file) and pushes the image to a GCP artifact registry.
+The `.github/workflows/push.yml` builds a fully statically linked version of `hpci`, pulls the test docker image, and runs the new `hpci` binary to connect to the OpenPBS docker container and run a basic job submission.
+
+## Testing locally
+
+The `makefile` has convenience commands for local testing.
+A summary of commands can be accessed using `make help`.
+
+For typical development and testing on an aarch64-darwin machine run:
+- `make PROJECT=[GCP_PROJECT_NAME] pull` to pull docker image
+- `make PROJECT=[GCP_PROJECT_NAME] run` to run OpenPBS docker container
+- In a seperate terminal run `ls app/*.hs | entr make test` to recompile and run tests eachtime `hpci` haskell files are saved (requires installing [entr](https://github.com/eradman/entr))
+- `make stop` to stop (and automatically remove) docker container when finished

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,8 +10,8 @@ import Network.SSH.Client.LibSSH2
 
 runCommand :: Session -> String -> IO (Int, BSL.ByteString)
 runCommand s cmd = withChannel s $ \ch -> do
-         channelExecute ch cmd
-         readAllChannel ch
+  channelExecute ch cmd
+  readAllChannel ch
 
 parseSubmissionResult :: (Int, BSL.ByteString) -> String
 parseSubmissionResult = BSL8.unpack . head . BSL8.split '.' . snd
@@ -21,7 +21,7 @@ parseQstatResponse r = head $ tail $ reverse $ words $ head $ drop 2 $ lines $ B
 
 checkStatus :: Session -> String -> IO String
 checkStatus s jid = do
-  jobStatus <- runCommand s ("qstat -x " ++ jid)
+  jobStatus <- runCommand s ("/opt/pbs/bin/qstat -x " ++ jid)
   return (parseQstatResponse jobStatus)
 
 pollUntilFinished :: Session -> String -> IO ()
@@ -54,7 +54,7 @@ runHpci user host port command public private script logFile = do
   putStrLn $ "Sent: " ++ script ++ " - "++ show scriptSize ++ " bytes."
 
   -- Submit job using script file
-  submissionResult <- runCommand session (command ++ " " ++ script)
+  submissionResult <- runCommand session (command ++ " " ++ takeFileName script)
 
   let jobId = parseSubmissionResult submissionResult
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,5 @@
 # inspired by https://github.com/dask/dask-jobqueue/blob/main/ci/pbs/Dockerfile
-# multi-stage build
-# build script will be triggered
-FROM debian:10.13-slim AS builder
+FROM debian:10.13-slim
 # install dependencies for building
 RUN apt-get update
 RUN apt-get -y install gcc make libtool libhwloc-dev libx11-dev \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -38,6 +38,8 @@ WORKDIR "/"
 # clean up install
 RUN rm -r /src/openpbs 
 
+ENV PATH /opt/pbs/bin:$PATH
+
 # Copy entrypoint
 COPY ./*.sh /
 RUN chmod a+x ./*.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -15,7 +15,33 @@ RUN git clone --branch v23.06.06 https://github.com/openpbs/openpbs.git /src/ope
 
 WORKDIR "/src/openpbs"
 RUN bash ./autogen.sh
-RUN ./configure --prefix=/opt/pbs --host=amd
+RUN ./configure --prefix=/opt/pbs
+
+# build
 RUN make
 
-ENTRYPOINT ["bash"]
+# install
+RUN make install
+
+# configure
+RUN /opt/pbs/libexec/pbs_postinstall
+
+# install dependencies for running
+RUN apt-get install -y expat libedit2 postgresql python3 postgresql-contrib sendmail-bin \
+      sudo tcl tk libical3 libcjson1 openssh-server
+
+RUN sed -i 's/PBS_START_MOM=0/PBS_START_MOM=1/g' /etc/pbs.conf
+
+RUN chmod 4755 /opt/pbs/sbin/pbs_iff /opt/pbs/sbin/pbs_rcp
+ 
+WORKDIR "/"
+# clean up install
+RUN rm -r /src/openpbs 
+
+# Copy entrypoint
+COPY ./*.sh /
+RUN chmod a+x ./*.sh
+
+EXPOSE 22
+
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+pbs_conf_file=/etc/pbs.conf
+mom_conf_file=/var/spool/pbs/mom_priv/config
+hostname=$(hostname)
+
+# replace hostname in pbs.conf and mom_priv/config
+sed -i "s/PBS_SERVER=.*/PBS_SERVER=$hostname/" $pbs_conf_file
+sed -i "s/\$clienthost .*/\$clienthost $hostname/" $mom_conf_file
+
+# start PBS Pro
+/etc/init.d/pbs start
+
+# start ssh service
+/etc/init.d/ssh start
+
+# create default non-root user
+adduser pbsuser
+
+cp -R /tmp/.ssh /home/pbsuser/.ssh
+chown -R pbsuser /home/pbsuser/.ssh
+chmod 700 /home/pbsuser/.ssh
+
+exec "$@"

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -18,7 +18,7 @@ useradd -m -u 1000 -s /bin/bash pbsuser
 
 mkdir -p /home/pbsuser/.ssh
 cp /tmp/authorized_keys /home/pbsuser/.ssh/authorized_keys
-chown -R pbsuser /home/pbsuser/.ssh
+chown -R pbsuser:pbsuser /home/pbsuser/.ssh
 chmod 700 /home/pbsuser/.ssh
 chmod 600 /home/pbsuser/.ssh
 

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -16,8 +16,10 @@ sed -i "s/\$clienthost .*/\$clienthost $hostname/" $mom_conf_file
 # create default non-root user
 useradd -m -u 1000 -s /bin/bash pbsuser
 
-cp -R /tmp/.ssh /home/pbsuser/.ssh
+mkdir -p /home/pbsuser/.ssh
+cp /tmp/authorized_keys /home/pbsuser/.ssh/authorized_keys
 chown -R pbsuser /home/pbsuser/.ssh
 chmod 700 /home/pbsuser/.ssh
+chmod 600 /home/pbsuser/.ssh
 
 exec "$@"

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -18,8 +18,10 @@ useradd -m -u 1000 -s /bin/bash pbsuser
 
 mkdir -p /home/pbsuser/.ssh
 cp /tmp/authorized_keys /home/pbsuser/.ssh/authorized_keys
-chown -R pbsuser:pbsuser /home/pbsuser/.ssh
 chmod 700 /home/pbsuser/.ssh
-chmod 600 /home/pbsuser/.ssh
+chmod 644 /home/pbsuser/.ssh/authorized_keys
+chown -R pbsuser:pbsuser /home/pbsuser/.ssh
+
+service ssh restart
 
 exec "$@"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Update path
+echo 'source /etc/profile.d/pbs.sh' >> /etc/bash.bashrc
+
+# Reduce time between PBS scheduling and add history
+qmgr -c "set server scheduler_iteration = 20"
+qmgr -c "set server job_history_enable = True"
+qmgr -c "set server job_history_duration = 24:00:00"
+
+# Start hanging process to leave the container up and running
+sleep infinity

--- a/ci/test_job.pbs
+++ b/ci/test_job.pbs
@@ -1,0 +1,11 @@
+#! /bin/bash
+#PBS -N testjob
+#PBS -S /bin/bash
+#PBS -q workq
+#PBS -j oe
+
+set -eu -0 pipefail
+
+qstat --version
+
+echo "$(qstat --version)" > test_job.log 2>&1

--- a/makefile
+++ b/makefile
@@ -29,7 +29,15 @@ interact: ## Start interactive terminal access to running docker container
 
 .PHONY: test
 test: ## Compile HPCI and test with dockerised OpenPBS (requires `make run` first)
-	cabal run exes -- pbsuser localhost 2222 qsub ci/test_key.pub ci/test_key ci/test_job.pbs remote_action.log
+	cabal run exes -- \
+		pbsuser \
+		localhost \
+		2222 \
+		/opt/pbs/bin/qsub \
+		ci/test_key.pub \
+		ci/test_key \
+		ci/test_job.pbs \
+		test_job.log
 
 .PHONY: stop
 stop: ## Stop the running docker container

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ run:
 	-p 2222:22 \
 	--name $(IMAGE) \
 	-h pbs_container \
-	-v ./ci/test_key.pub:/tmp/.ssh/authorized_keys:ro \
+	-v ./ci/test_key.pub:/tmp/authorized_keys:ro \
 	$(DOCKER_TAG) /bin/bash -l /run.sh
 	
 interact:

--- a/makefile
+++ b/makefile
@@ -2,15 +2,16 @@ IMAGE=pbs
 DOCKER_TAG=$(IMAGE)-hpci
 
 docker:
-	docker build -t $(DOCKER_TAG) test/integration
+	docker build -t $(DOCKER_TAG) ci
 
+# requires creating an ssh key in the `ci` directory
 run:
 	docker run \
 	-d --rm \
 	-p 2222:22 \
 	--name $(IMAGE) \
 	-h pbs_container \
-	-v ./test/integration/test_key.pub:/tmp/.ssh/authorized_keys:ro \
+	-v ./ci/test_key.pub:/tmp/.ssh/authorized_keys:ro \
 	$(DOCKER_TAG) /bin/bash -l /run.sh
 	
 interact:

--- a/makefile
+++ b/makefile
@@ -1,4 +1,20 @@
-DOCKER_TAG=pbs-hpci
+IMAGE=pbs
+DOCKER_TAG=$(IMAGE)-hpci
 
 docker:
-	docker build --platform linux/amd64 -t $(DOCKER_TAG) test/integration
+	docker build -t $(DOCKER_TAG) test/integration
+
+run:
+	docker run \
+	-d --rm \
+	-p 2222:22 \
+	--name $(IMAGE) \
+	-h pbs_container \
+	-v ./test/integration/test_key.pub:/tmp/.ssh/authorized_keys:ro \
+	$(DOCKER_TAG) /bin/bash -l /run.sh
+	
+interact:
+	docker exec -it --user pbsuser $(IMAGE) /bin/bash -l
+
+stop:
+	docker stop $(IMAGE)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+DOCKER_TAG=pbs-hpci
+
+docker:
+	docker build --platform linux/amd64 -t $(DOCKER_TAG) test/integration

--- a/makefile
+++ b/makefile
@@ -1,21 +1,41 @@
-IMAGE=pbs
-DOCKER_TAG=$(IMAGE)-hpci
+# Makefile for hpci
+REGION:=australia-southeast1
+REGISTRY:=$(REGION)-docker.pkg.dev/$(PROJECT)/docker/
+IMAGE:=pbs
+DOCKER_TAG:=$(REGISTRY)$(IMAGE):latest
 
-docker:
+.PHONY: docker
+docker: ## Build a docker image. Only works on x86_64-linux
 	docker build -t $(DOCKER_TAG) ci
 
-# requires creating an ssh key in the `ci` directory
-run:
+.PHONY: pull
+pull: ## Pull a docker image from artifact registry (useful on non-x86_64 machines. Provide REGISTRY argument on commandline (e.g. make REGISTRY=blah pull)
+	docker pull --platform linux/amd64 $(DOCKER_TAG)
+
+.PHONY: run
+run: ## Start a OpenPBS server and ssh server inside docker container (This requires creating an ssh key called `test_key` in the `ci` directory)
 	docker run \
+	--platform linux/amd64 \
 	-d --rm \
 	-p 2222:22 \
 	--name $(IMAGE) \
 	-h pbs_container \
 	-v ./ci/test_key.pub:/tmp/authorized_keys:ro \
-	$(DOCKER_TAG) /bin/bash -l /run.sh
-	
-interact:
-	docker exec -it --user pbsuser $(IMAGE) /bin/bash -l
+	$(DOCKER_TAG) bash /run.sh
 
-stop:
+.PHONY: interact
+interact: ## Start interactive terminal access to running docker container
+	docker exec -it --user pbsuser $(IMAGE) bash
+
+.PHONY: test
+test: ## Compile HPCI and test with dockerised OpenPBS (requires `make run` first)
+	cabal run exes -- pbsuser localhost 2222 qsub ci/test_key.pub ci/test_key ci/test_job.pbs remote_action.log
+
+.PHONY: stop
+stop: ## Stop the running docker container
 	docker stop $(IMAGE)
+
+.PHONY: help
+help: ## Display available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk \
+		'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,0 +1,21 @@
+# inspired by https://github.com/dask/dask-jobqueue/blob/main/ci/pbs/Dockerfile
+# multi-stage build
+# build script will be triggered
+FROM debian:10.13-slim AS builder
+# install dependencies for building
+RUN apt-get update
+RUN apt-get -y install gcc make libtool libhwloc-dev libx11-dev \
+      libxt-dev libedit-dev libical-dev ncurses-dev perl \
+      postgresql-server-dev-all postgresql-contrib python3-dev tcl-dev tk-dev swig \
+      libexpat-dev libssl-dev libxext-dev libxft-dev autoconf \
+      automake g++ libcjson-dev git
+
+# get known PBS Pro source code
+RUN git clone --branch v23.06.06 https://github.com/openpbs/openpbs.git /src/openpbs
+
+WORKDIR "/src/openpbs"
+RUN bash ./autogen.sh
+RUN ./configure --prefix=/opt/pbs --host=amd
+RUN make
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
Adds new actions workflow:
- Builds a image with dockerised PBS and ssh-server (if there have been changes to `ci` directory
- Pushes image to GCP artifact registry

Edits hpci build workflow:
- loads test ssh keys to runner
- pulls PBS docker image from GCP
- initialises pbs server
- tests hpci against dockerised pbs server 