### PR TITLE
Slurm non-failing error bugfix

### DIFF
--- a/.github/workflows/build-pbs.yml
+++ b/.github/workflows/build-pbs.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           create_credentials_file: "true"
           service_account: "grunner-ci-sa@${{secrets.PROJECT_ID}}.iam.gserviceaccount.com"
-          workload_identity_provider: "projects/${{secrets.PROJECT_NUMBER}}/locations/global/workloadIdentityPools/${{secrets.PROJECT_ID}}-workload-identity-pool/providers/github-provider"
+          workload_identity_provider: "projects/${{secrets.PROJECT_NUMBER}}/locations/global/workloadIdentityPools/hpci-workload-identity-pool/providers/github-provider"
 
       - name: Set up gcloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/ci/test_exit.pbs
+++ b/ci/test_exit.pbs
@@ -1,0 +1,10 @@
+#! /bin/bash
+#PBS -N testjob
+#PBS -S /bin/bash
+#PBS -j oe
+
+set -eu -o pipefail
+
+
+echo "Qstat version: $(qstat --version)" > test_job.log 2>&1
+exit 7

--- a/ci/test_exit.slurm
+++ b/ci/test_exit.slurm
@@ -1,0 +1,7 @@
+#! /bin/bash
+#SBATCH --job-name=testjob
+
+set -eu -o pipefail
+
+echo "Sbatch version: $(sbatch --version)" > test_job.log 2>&1
+exit 7

--- a/src/Schedule.hs
+++ b/src/Schedule.hs
@@ -8,7 +8,7 @@ module Schedule (
 -- Import from external libraries
 import Control.Concurrent
 import Data.List (intercalate)
-import Data.Maybe (listToMaybe)
+import Data.Maybe (listToMaybe, mapMaybe)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.Text (Text)
@@ -16,6 +16,7 @@ import qualified Data.Text as T
 import qualified Data.Map.Strict as Map
 import System.Exit
 import System.FilePath
+import Text.Read (readMaybe)
 
 -- Import from FFI library
 import Network.SSH.Client.LibSSH2 (
@@ -86,7 +87,7 @@ getKey :: Scheduler -> StatusType -> String
 getKey PBS JobState       = "job_state"
 getKey PBS JobExitCode    = "Exit_status"
 getKey Slurm JobState     = "State"
-getKey Slurm JobExitCode  = "ExitCode"
+getKey Slurm JobExitCode  = "ExitCode,DerivedExitCode"
 
 -- Parses a field from typical `qstat -xf` response (example below)
 --
@@ -120,8 +121,15 @@ checkStatus PBS s jid statusType = do
     Left err    -> return $ Left err
 checkStatus Slurm s jid statusType = do
   jobStatus <- runCommand s ("sacct -j " <> showJobId jid <> " --format=" <> getKey Slurm statusType <> " --noheader -P -X")
-  let status = head $ T.split (==':') $ T.strip . T.pack . BSL8.unpack $ snd jobStatus
-  return $ Right status
+  let raw = T.strip . T.pack . BSL8.unpack $ snd jobStatus
+  case statusType of
+    JobState    -> return $ Right $ head $ T.split (== ':') raw
+    JobExitCode -> return $ Right $ maxExitCode raw
+
+maxExitCode :: T.Text -> T.Text
+maxExitCode raw =
+  let nums = mapMaybe (readMaybe . T.unpack) (T.split (`elem` (":|" :: String)) raw)
+  in T.pack . show $ maximum (0 : nums :: [Int])
 
 -- TODO: check if I need to also support short codes CA, CD, F, OOM, TO
 isFinished :: Scheduler -> Text -> Bool

--- a/src/Schedule.hs
+++ b/src/Schedule.hs
@@ -86,7 +86,7 @@ getKey :: Scheduler -> StatusType -> String
 getKey PBS JobState       = "job_state"
 getKey PBS JobExitCode    = "Exit_status"
 getKey Slurm JobState     = "State"
-getKey Slurm JobExitCode  = "DerivedExitCode"
+getKey Slurm JobExitCode  = "ExitCode"
 
 -- Parses a field from typical `qstat -xf` response (example below)
 --

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -64,8 +64,8 @@ integrationSpec = describe "Docker Integration Tests" $ do
 
       jobExitCode `shouldBe` ExitSuccess
 
-    it "crashes when there is a slurm submission error" $ \(slurm, _pbs) -> do
-      let cliArgs = [ "--user", targetPort slurm
+    it "crashes when there is a slurm submission error (wrong partition)" $ \(slurm, _pbs) -> do
+      let cliArgs = [ "--user", targetUser slurm
 			           , "--host", "127.0.0.1"
 			           , "--port", targetPort slurm
 			           , "--publicKey", "test_key.pub"
@@ -80,6 +80,23 @@ integrationSpec = describe "Docker Integration Tests" $ do
       (jobExitCode, _, _) <- runHpci cliArgs
 
       jobExitCode `shouldBe` ExitFailure 1
+
+    it "crashes when there is a slurm submission error (non-zero exit)" $ \(slurm, _pbs) -> do
+      let cliArgs = [ "--user", targetUser slurm
+			           , "--host", "127.0.0.1"
+			           , "--port", targetPort slurm
+			           , "--publicKey", "test_key.pub"
+			           , "--privateKey", "test_key"
+			           , "schedule"
+			           , "--scheduler", "slurm"
+			           , "--script", "ci/test_exit.slurm"
+			           , "--logFile", "test_job.log"
+			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
+                ]
+
+      (jobExitCode, _, _) <- runHpci cliArgs
+
+      jobExitCode `shouldBe` ExitFailure 7
 
     it "crashes when there is a pbs job submission error" $ \(_slurm, pbs) -> do
       let cliArgs = [ "--user", targetUser pbs

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -98,7 +98,7 @@ integrationSpec = describe "Docker Integration Tests" $ do
 
       jobExitCode `shouldBe` ExitFailure 7
 
-    it "crashes when there is a pbs job submission error" $ \(_slurm, pbs) -> do
+    it "crashes when there is a pbs job submission error (wrong queue)" $ \(_slurm, pbs) -> do
       let cliArgs = [ "--user", targetUser pbs
 			           , "--host", "127.0.0.1"
 			           , "--port", targetPort pbs
@@ -114,6 +114,23 @@ integrationSpec = describe "Docker Integration Tests" $ do
       (jobExitCode, _, _) <- runHpci cliArgs
 
       jobExitCode `shouldBe` ExitFailure 1
+
+    it "crashes when there is a pbs job submission error (non-zero exit)" $ \(_slurm, pbs) -> do
+      let cliArgs = [ "--user", targetUser pbs
+			           , "--host", "127.0.0.1"
+			           , "--port", targetPort pbs
+			           , "--publicKey", "test_key.pub"
+			           , "--privateKey", "test_key"
+			           , "schedule"
+			           , "--scheduler", "pbs"
+			           , "--script", "ci/test_exit.pbs"
+			           , "--logFile", "test_job.log"
+			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
+                ]
+
+      (jobExitCode, _, _) <- runHpci cliArgs
+
+      jobExitCode `shouldBe` ExitFailure 7
 
     it "succeeds when a '--scheduler-arg' successfully overrides a slurm submission error" $ \(slurm, _pbs) -> do
       let cliArgs = [ "--user", targetUser slurm


### PR DESCRIPTION
This PR fixes the case where an error in a Slurm CI workflow was not causing `hpci` to exit with non-zero exit code.

It also adds a test to specifically verify this.