### PR TITLE
Add verbose error messages

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,15 +1,26 @@
+module Main where
+
+import Control.Exception (catch, displayException)
+import System.Exit (exitFailure)
+
 import Cli
 import Exec
 import Schedule
+import Errors (wrapSshErrors, HpciUserError)
 
 runHpci :: Options -> IO ()
-runHpci opts = do
+runHpci opts = wrapSshErrors $ do
   case optCommand opts of 
     Exec execStr -> runExec opts execStr
 
     _            -> runSchedule opts
 
+handleHpciError :: HpciUserError -> IO ()
+handleHpciError e = do
+  putStrLn $ displayException e
+  exitFailure
+
 main :: IO ()
 main = do
   opts <- parseOptions
-  runHpci opts
+  runHpci opts `catch` handleHpciError

--- a/hpci.cabal
+++ b/hpci.cabal
@@ -48,6 +48,7 @@ library
     , text
     , retry
     , exceptions
+    , directory
 
 executable hpci-exe
   import:         common-options

--- a/hpci.cabal
+++ b/hpci.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            hpci
-version:         0.0.5
+version:         0.1.3
 license:         GPL-3.0-or-later
 build-type:      Simple
 license-file:    LICENSE

--- a/hpci.cabal
+++ b/hpci.cabal
@@ -33,6 +33,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
      Exec
+    , Errors
     , Cli
     , Helpers
     , Schedule
@@ -71,6 +72,7 @@ test-suite hpci-test
     , hpci
     , filepath
     , hspec
+    , libssh2 >= 0.2.0.9
     , tasty
     , tasty-quickcheck
     , tasty-hspec >= 1.1.5

--- a/hpci.cabal
+++ b/hpci.cabal
@@ -47,6 +47,7 @@ library
     , optparse-applicative
     , text
     , retry
+    , exceptions
 
 executable hpci-exe
   import:         common-options

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -10,41 +10,54 @@ import Control.Exception (
   , catches
   , throwIO
   , IOException)
+import Data.List (isInfixOf)
 import Data.Typeable (Typeable)
 import Network.SSH.Client.LibSSH2.Errors (
   ErrorCode(..)
   , SftpErrorCode(..))
+import System.IO.Error (isDoesNotExistError, ioeGetLocation)
 
-newtype HpciUserError = HpciUserError String
+data HpciUserError
+  = SshError String
+  | NetworkError String
+  | LocalFileError String
   deriving (Typeable)
 
 instance Show HpciUserError where
-  show (HpciUserError message) = "hcpi error: " ++ message
+  show (SshError message) = "hcpi SSH Error: " ++ message
+  show (NetworkError message) = "hcpi Network Error: " ++ message
+  show (LocalFileError message) = "hcpi Local File Error: " ++ message
 
 instance Exception HpciUserError where
-  displayException (HpciUserError message) = "SSH Connection Failed\n" ++ message
-  -- TODO why separate errors for ssh connection failures?
+  displayException (SshError message) = "SSH Connection Failed\n" ++ message
+  displayException (NetworkError message) = "Network Connection Failed\n" ++ message
+  displayException (LocalFileError message) = "Local File Missing Or Inaccessible\n" ++ message
 
 renderSshError :: ErrorCode -> String
 renderSshError err = case err of
   FILE ->
-    "Could not read your SSH keys or known_hosts file.\n" ++ -- TODO check if known_hosts error is possible with my code?
+    "Could not read your SSH keys.\n" ++
     "Fix: Ensure keys exist and have the correct permissions."
 
   AUTHENTICATION_FAILED ->
     "The HPC rejected your login attempt.\n" ++
-    "Fix: ensure your public key is in the login node's authorized_keys file."
+    "Fix: ensure your username is correct and that your public ssh key is in the login node's authorized_keys file."
 
   TIMEOUT ->
     "The connection to the HPC timed out.\n" ++
     "Fix: Check the cluster network connection."
 
+  -- Not currently possible, but leaving in regardless
   ERROR_KNOWN_HOSTS ->
-    "The HPC login node's identity does not match your known_hosts file.\n" ++ -- TODO check if we're using known_hosts
+    "The HPC login node's identity does not match your known_hosts file.\n" ++
     "Fix: Remove the old key from your runner's known_hosts file"
 
   KEX_FALIURE ->
    "Encryption key exchange failed. The HPC node is using incompantible SSH settings."
+
+  SCP_PROTOCOL ->
+    "An SCP file transfer failed. The remote file does not exist or access was denied.\n" ++
+    "Fix: ensure HPC job log file was created at the specified path"
 
   _ -> "An unexpected SSH error occured: " ++ show err ++ ")."
 
@@ -58,13 +71,19 @@ wrapSshErrors :: IO a -> IO a
 wrapSshErrors action = action `catches` [Handler handleSsh, Handler handleSftp, Handler handleIO]
   where
     handleSsh :: ErrorCode -> IO a
-    handleSsh err = throwIO $ HpciUserError $ renderSshError err
+    handleSsh err = throwIO $ SshError $ renderSshError err
 
     handleSftp :: SftpErrorCode -> IO a
-    handleSftp err = throwIO $ HpciUserError $ renderSftpError err
+    handleSftp err = throwIO $ SshError $ renderSftpError err
 
     handleIO :: IOException -> IO a
-    handleIO err = throwIO $ HpciUserError $
+    handleIO err
+      | isDoesNotExistError err && not ("Network.Socket.connect" `isInfixOf` displayException err) = throwIO $ LocalFileError $
+      "Could not read a required local file before sending it to the HPC.\n" ++
+      "System Error: " ++ displayException err ++ "\n" ++
+      "Fix: ensure the file exists at the path provided by your CLI arguments"
+
+      | otherwise = throwIO $ NetworkError $
       "Could not establish a network connection to the HPC node.\n" ++
       "System Error: " ++ displayException err ++ "\n" ++
       "Fix: Check that host IP and port are correct."

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -43,6 +43,10 @@ renderSshError err = case err of
     "The HPC rejected your login attempt.\n" ++
     "Fix: ensure your username is correct and that your public ssh key is in the login node's authorized_keys file."
 
+  PUBLICKEY_UNVERIFIED ->
+    "The HPC rejected your private key signature\n" ++
+    "Fix: ensure your --privateKey file is correct."
+
   TIMEOUT ->
     "The connection to the HPC timed out.\n" ++
     "Fix: Check the cluster network connection."

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -1,0 +1,70 @@
+module Errors (
+  wrapSshErrors
+  , renderSshError
+  , HpciUserError(..)
+) where
+
+import Control.Exception (
+  Exception(..)
+  , Handler(..)
+  , catches
+  , throwIO
+  , IOException)
+import Data.Typeable (Typeable)
+import Network.SSH.Client.LibSSH2.Errors (
+  ErrorCode(..)
+  , SftpErrorCode(..))
+
+newtype HpciUserError = HpciUserError String
+  deriving (Typeable)
+
+instance Show HpciUserError where
+  show (HpciUserError message) = "hcpi error: " ++ message
+
+instance Exception HpciUserError where
+  displayException (HpciUserError message) = "SSH Connection Failed\n" ++ message
+  -- TODO why separate errors for ssh connection failures?
+
+renderSshError :: ErrorCode -> String
+renderSshError err = case err of
+  FILE ->
+    "Could not read your SSH keys or known_hosts file.\n" ++ -- TODO check if known_hosts error is possible with my code?
+    "Fix: Ensure keys exist and have the correct permissions."
+
+  AUTHENTICATION_FAILED ->
+    "The HPC rejected your login attempt.\n" ++
+    "Fix: ensure your public key is in the login node's authorized_keys file."
+
+  TIMEOUT ->
+    "The connection to the HPC timed out.\n" ++
+    "Fix: Check the cluster network connection."
+
+  ERROR_KNOWN_HOSTS ->
+    "The HPC login node's identity does not match your known_hosts file.\n" ++ -- TODO check if we're using known_hosts
+    "Fix: Remove the old key from your runner's known_hosts file"
+
+  KEX_FALIURE ->
+   "Encryption key exchange failed. The HPC node is using incompantible SSH settings."
+
+  _ -> "An unexpected SSH error occured: " ++ show err ++ ")."
+
+renderSftpError :: SftpErrorCode -> String
+renderSftpError err = case err of
+  FX_NO_SUCH_FILE -> "The requested remote file or directory does not exist on the HPC node."
+  FX_PERMISSION_DENIED -> "You do not have permission to access this remote file."
+  _ -> "An unexpected SFTP error occured (Code: " ++ show err ++ ")."
+
+wrapSshErrors :: IO a -> IO a
+wrapSshErrors action = action `catches` [Handler handleSsh, Handler handleSftp, Handler handleIO]
+  where
+    handleSsh :: ErrorCode -> IO a
+    handleSsh err = throwIO $ HpciUserError $ renderSshError err
+
+    handleSftp :: SftpErrorCode -> IO a
+    handleSftp err = throwIO $ HpciUserError $ renderSftpError err
+
+    handleIO :: IOException -> IO a
+    handleIO err = throwIO $ HpciUserError $
+      "Could not establish a network connection to the HPC node.\n" ++
+      "System Error: " ++ displayException err ++ "\n" ++
+      "Fix: Check that host IP and port are correct."

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes, ScopedTypeVariables #-}
 
 module Helpers (
   scpSendFileRetry
@@ -10,13 +10,17 @@ module Helpers (
   , sessionRetry
 ) where
 
+import System.Timeout (timeout)
+import Control.Exception (throwIO, IOException)
+import Control.Monad.Catch (Handler(..))
+import Network.SSH.Client.LibSSH2.Errors(ErrorCode(..))
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Control.Retry (
   exponentialBackoff
   , limitRetries
-  , recoverAll
+  , recovering
   , RetryPolicy)
 
 import Network.SSH.Client.LibSSH2.Foreign (
@@ -76,14 +80,26 @@ defaultRetryPolicy = exponentialBackoff 1000000 <> limitRetries 5
 --   and IO MockSession in tests
 sessionRetry :: RetryPolicy -> IO a -> IO a
 sessionRetry policy actionToRetry =
-  recoverAll policy (\_ -> actionToRetry)
+  recovering policy handlers (\_ -> actionToRetry)
+  where
+    handlers =
+      [ \_ -> Handler $ \(err :: ErrorCode) -> return $ case err of
+        FILE                  -> False -- don't retry if there are errors with keys
+        AUTHENTICATION_FAILED -> False -- don't rety if there is an auth error
+        _                     -> True
+      , \_ -> Handler $ \(_ :: IOException) -> return False
+      ]
 
 connect :: Connection -> IO Session
 connect connInfo = do
-  s <- sessionInit' (host connInfo) (port connInfo)
-  publicKeyAuthFile' s (user connInfo) (publicKey connInfo) (privateKey connInfo)
-  putStrLn "SSH session established"
-  return s
+  mSession <- timeout 10000000 $ sessionInit' (host connInfo) (port connInfo)
+  case mSession of
+    Nothing ->
+      throwIO $ userError "Network connection timed out after 10 seconds"
+    Just s -> do
+      publicKeyAuthFile' s (user connInfo) (publicKey connInfo) (privateKey connInfo)
+      putStrLn "SSH session established"
+      return s
 
 -- add policy arg
 connectWithRetry :: Connection -> IO Session

--- a/src/Schedule.hs
+++ b/src/Schedule.hs
@@ -7,6 +7,8 @@ module Schedule (
 
 -- Import from external libraries
 import Control.Concurrent
+import Control.Monad (when)
+import Control.Exception (throwIO)
 import Data.List (intercalate)
 import Data.Maybe (listToMaybe, mapMaybe)
 import qualified Data.ByteString.Lazy as BSL
@@ -14,9 +16,12 @@ import qualified Data.ByteString.Lazy.Char8 as BSL8
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Map.Strict as Map
+import System.Directory (getFileSize)
 import System.Exit
 import System.FilePath
 import Text.Read (readMaybe)
+
+import Errors (HpciUserError(..))
 
 -- Import from FFI library
 import Network.SSH.Client.LibSSH2 (
@@ -156,11 +161,16 @@ pollUntilFinished schedulerType connInfo jid interval = do
           threadDelay interval
           pollUntilFinished schedulerType connInfo jid interval
 
--- TODO: error handling for IO and parsing status of job
 runSchedule :: Options -> IO()
 runSchedule opts = do
     let connInfo                  = connectionInfo opts
         cmdOpts                   = optCommand opts
+        (Script scriptPath)       = script cmdOpts
+
+    -- Check script is not empty
+    size <- getFileSize scriptPath
+    when (size == 0) $
+      throwIO $ LocalFileError $ "The script file '" ++ scriptPath ++ "' is empty (0 bytes)."
 
     session <- connectWithRetry connInfo
 
@@ -168,13 +178,10 @@ runSchedule opts = do
     scriptSize <- scpSendFileRetry defaultRetryPolicy session (script cmdOpts)
 
     putStrLn $ "Sent: " <> show (script cmdOpts) <> " - " <> show scriptSize <> " bytes."
-    -- TODO add zero script size check
 
     -- Submit job using script file
     putStrLn $ "Command to run on server: " <> constructSubmissionCommand (scheduler cmdOpts) opts
 
-    -- Note: Add retry? I'm torn. I don't want to accidentally schedule multiple concurrent jobs.
-    --   Will use improved error handling instead
     submissionResult <- runCommand session (constructSubmissionCommand (scheduler cmdOpts) opts <> " 2>&1")
 
     let eitherJobId = parseSubmissionResult (scheduler cmdOpts) submissionResult
@@ -190,7 +197,6 @@ runSchedule opts = do
         sessionClose session
 
         -- Query job status
-        -- TODO: Add timeout?
         -- TODO: add user defined poll interval with default
         pollUntilFinished (scheduler cmdOpts) connInfo jobId 20000000
 

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -4,6 +4,7 @@ module Integrations (integrationSpec) where
 
 import Control.Monad.IO.Class (liftIO)
 import Data.Text (pack)
+import Data.List (isInfixOf)
 import qualified Data.Text.Lazy as LazyText
 import System.Directory (makeAbsolute)
 import System.Exit (ExitCode(..))
@@ -85,3 +86,22 @@ integrationSpec = describe "Docker Integration Tests" $ do
       it "escapes tricky characters in pbs '--scheduler-arg'" $ \(_slurm, pbs) -> do
         let extra = ["--scheduler-arg", "-l 'walltime=01:30:00'"]
         baseScheduleArgs pbs "pbs" "ci/test_job.pbs" extra `shouldExitWith` ExitSuccess
+
+    context "SSH Error messages" $ do
+      it "prints a verbose FILE error when SSH keys are missing" $ \(slurm, _) -> do
+        let badKeyArgs =
+              [ "--user", targetUser slurm
+              , "--host", "127.0.0.1"
+              , "--port", targetPort slurm
+              , "--publicKey", "/tmp/does_not_exist.pub"
+              , "--privateKey", "/tmp/does_not_exist.key"
+              , "schedule"
+              , "--scheduler", "slurm"
+              , "--script", "ci/test_job.slurm"
+              , "--logFile", "test_job.log"
+              ]
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` ("Could not read your SSH keys" `isInfixOf`)

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -145,24 +145,24 @@ integrationSpec = describe "Docker Integration Tests" $ do
         (stdout ++ stderr) `shouldSatisfy` ("Could not establish a network connection" `isInfixOf`)
         (stdout ++ stderr) `shouldSatisfy` ("Connection refused" `isInfixOf`)
 
-      -- it "prints a verbose network error when host is incorrect" $ \(slurm, _) -> do
-      --   let badKeyArgs =
-      --         [ "--user", targetUser slurm
-      --         , "--host", "127.0.0.2"
-      --         , "--port", targetPort slurm
-      --         , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
-      --         , "--privateKey", "ci/fake_key" -- file exists but is not valid key
-      --         , "schedule"
-      --         , "--scheduler", "slurm"
-      --         , "--script", "ci/test_job.slurm"
-      --         , "--logFile", "test_job.log"
-      --         ]
+      it "prints a verbose network error when host is incorrect" $ \(slurm, _) -> do
+        let badKeyArgs =
+              [ "--user", targetUser slurm
+              , "--host", "127.0.0.2"
+              , "--port", targetPort slurm
+              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
+              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
+              , "schedule"
+              , "--scheduler", "slurm"
+              , "--script", "ci/test_job.slurm"
+              , "--logFile", "test_job.log"
+              ]
 
-      --   (exitCode, stdout, stderr) <- runHpci badKeyArgs
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
-      --   exitCode `shouldNotBe` ExitSuccess
-      --   (stdout ++ stderr) `shouldSatisfy` ("Could not establish a network connection" `isInfixOf`)
-      --   (stdout ++ stderr) `shouldSatisfy` ("Connection refused" `isInfixOf`)
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` ("Network connection timed out" `isInfixOf`)
+        (stdout ++ stderr) `shouldSatisfy` ("timeout" `isInfixOf`)
 
 -- user error
 -- host error

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -10,6 +10,8 @@ import System.Directory (makeAbsolute)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
 import Test.Hspec
+import Errors (renderSshError)
+import Network.SSH.Client.LibSSH2.Errors (ErrorCode(..))
 
 data SshTarget = SshTarget
   { targetPort :: String
@@ -104,4 +106,66 @@ integrationSpec = describe "Docker Integration Tests" $ do
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
         exitCode `shouldNotBe` ExitSuccess
-        (stdout ++ stderr) `shouldSatisfy` ("Could not read your SSH keys" `isInfixOf`)
+        (stdout ++ stderr) `shouldSatisfy` (renderSshError FILE `isInfixOf`)
+
+      it "prints a verbose AUTHENTICATION_FAILED error when SSH keys are invalid" $ \(slurm, _) -> do
+        let badKeyArgs =
+              [ "--user", targetUser slurm
+              , "--host", "127.0.0.1"
+              , "--port", targetPort slurm
+              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
+              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
+              , "schedule"
+              , "--scheduler", "slurm"
+              , "--script", "ci/test_job.slurm"
+              , "--logFile", "test_job.log"
+              ]
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` (renderSshError AUTHENTICATION_FAILED `isInfixOf`)
+
+      it "prints a verbose network error when port is incorrect" $ \(slurm, _) -> do
+        let badKeyArgs =
+              [ "--user", targetUser slurm
+              , "--host", "127.0.0.1"
+              , "--port", show (read (targetPort slurm) + 100 :: Int)
+              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
+              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
+              , "schedule"
+              , "--scheduler", "slurm"
+              , "--script", "ci/test_job.slurm"
+              , "--logFile", "test_job.log"
+              ]
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` ("Could not establish a network connection" `isInfixOf`)
+        (stdout ++ stderr) `shouldSatisfy` ("Connection refused" `isInfixOf`)
+
+      -- it "prints a verbose network error when host is incorrect" $ \(slurm, _) -> do
+      --   let badKeyArgs =
+      --         [ "--user", targetUser slurm
+      --         , "--host", "127.0.0.2"
+      --         , "--port", targetPort slurm
+      --         , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
+      --         , "--privateKey", "ci/fake_key" -- file exists but is not valid key
+      --         , "schedule"
+      --         , "--scheduler", "slurm"
+      --         , "--script", "ci/test_job.slurm"
+      --         , "--logFile", "test_job.log"
+      --         ]
+
+      --   (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+      --   exitCode `shouldNotBe` ExitSuccess
+      --   (stdout ++ stderr) `shouldSatisfy` ("Could not establish a network connection" `isInfixOf`)
+      --   (stdout ++ stderr) `shouldSatisfy` ("Connection refused" `isInfixOf`)
+
+-- user error
+-- host error
+-- scheduler
+-- logfile
+-- script

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -30,16 +30,24 @@ runHpci inputArgs = readProcessWithExitCode "cabal" (["run", "hpci-exe", "--"] +
 baseScheduleArgs :: SshTarget -> String -> String -> [String] -> [String]
 baseScheduleArgs target scheduler script extraArgs =
   [ "--user", targetUser target
-	, "--host", "127.0.0.1"
-	, "--port", targetPort target
-	, "--publicKey", "test_key.pub"
-	, "--privateKey", "test_key"
-	, "schedule"
-	, "--scheduler", scheduler
-	, "--script", script
-	, "--logFile", "test_job.log"
-	, "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
+  , "--host", "127.0.0.1"
+  , "--port", targetPort target
+  , "--publicKey", "test_key.pub"
+  , "--privateKey", "test_key"
+  , "schedule"
+  , "--scheduler", scheduler
+  , "--script", script
+  , "--logFile", "test_job.log"
+  , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
   ] ++ extraArgs
+
+-- helper to make tests more dry
+replaceArg :: String -> String -> [String] -> [String]
+replaceArg _ _ [] = []
+replaceArg flag newVal (x:y:rest)
+ | x == flag = x : newVal : rest
+ | otherwise = x : replaceArg flag newVal (y:rest)
+replaceArg _ _ [x] = [x]
 
 shouldExitWith :: [String] -> ExitCode -> IO()
 shouldExitWith args expectedCode = do
@@ -91,17 +99,9 @@ integrationSpec = describe "Docker Integration Tests" $ do
 
     context "SSH Error messages" $ do
       it "prints a verbose FILE error when SSH keys are missing" $ \(slurm, _) -> do
-        let badKeyArgs =
-              [ "--user", targetUser slurm
-              , "--host", "127.0.0.1"
-              , "--port", targetPort slurm
-              , "--publicKey", "/tmp/does_not_exist.pub"
-              , "--privateKey", "/tmp/does_not_exist.key"
-              , "schedule"
-              , "--scheduler", "slurm"
-              , "--script", "ci/test_job.slurm"
-              , "--logFile", "test_job.log"
-              ]
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        let badKeyArgs = replaceArg "--publicKey" "/tmp/does_not_exist.pub" $ replaceArg "--privateKey" "/tmp/does_not_exist.key" baseArgs
 
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
@@ -109,17 +109,10 @@ integrationSpec = describe "Docker Integration Tests" $ do
         (stdout ++ stderr) `shouldSatisfy` (renderSshError FILE `isInfixOf`)
 
       it "prints a verbose AUTHENTICATION_FAILED error when SSH keys are invalid" $ \(slurm, _) -> do
-        let badKeyArgs =
-              [ "--user", targetUser slurm
-              , "--host", "127.0.0.1"
-              , "--port", targetPort slurm
-              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
-              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
-              , "schedule"
-              , "--scheduler", "slurm"
-              , "--script", "ci/test_job.slurm"
-              , "--logFile", "test_job.log"
-              ]
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        -- key file exists but is not the correct key
+        let badKeyArgs = replaceArg "--publicKey" "ci/fake_key.pub" $ replaceArg "--privateKey" "ci/fake_key" baseArgs
 
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
@@ -127,17 +120,9 @@ integrationSpec = describe "Docker Integration Tests" $ do
         (stdout ++ stderr) `shouldSatisfy` (renderSshError AUTHENTICATION_FAILED `isInfixOf`)
 
       it "prints a verbose network error when port is incorrect" $ \(slurm, _) -> do
-        let badKeyArgs =
-              [ "--user", targetUser slurm
-              , "--host", "127.0.0.1"
-              , "--port", show (read (targetPort slurm) + 100 :: Int)
-              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
-              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
-              , "schedule"
-              , "--scheduler", "slurm"
-              , "--script", "ci/test_job.slurm"
-              , "--logFile", "test_job.log"
-              ]
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        let badKeyArgs = replaceArg "--port" (show (read (targetPort slurm) + 100 :: Int)) baseArgs
 
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
@@ -146,26 +131,16 @@ integrationSpec = describe "Docker Integration Tests" $ do
         (stdout ++ stderr) `shouldSatisfy` ("Connection refused" `isInfixOf`)
 
       it "prints a verbose network error when host is incorrect" $ \(slurm, _) -> do
-        let badKeyArgs =
-              [ "--user", targetUser slurm
-              , "--host", "127.0.0.2"
-              , "--port", targetPort slurm
-              , "--publicKey", "ci/fake_key.pub" -- file exists but is not valid key
-              , "--privateKey", "ci/fake_key" -- file exists but is not valid key
-              , "schedule"
-              , "--scheduler", "slurm"
-              , "--script", "ci/test_job.slurm"
-              , "--logFile", "test_job.log"
-              ]
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        let badKeyArgs = replaceArg "--host" "127.0.0.2" baseArgs
 
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
         exitCode `shouldNotBe` ExitSuccess
-        (stdout ++ stderr) `shouldSatisfy` ("Network connection timed out" `isInfixOf`)
-        (stdout ++ stderr) `shouldSatisfy` ("timeout" `isInfixOf`)
+        (stdout ++ stderr) `shouldSatisfy` ("Network connection timed" `isInfixOf`)
 
 -- user error
--- host error
 -- scheduler
 -- logfile
 -- script

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -24,184 +24,64 @@ setupContainerTargets = pure
 runHpci :: [String] -> IO (ExitCode, String, String)
 runHpci inputArgs = readProcessWithExitCode "cabal" (["run", "hpci-exe", "--"] ++ inputArgs) ""
 
+baseScheduleArgs :: SshTarget -> String -> String -> [String] -> [String]
+baseScheduleArgs target scheduler script extraArgs =
+  [ "--user", targetUser target
+	, "--host", "127.0.0.1"
+	, "--port", targetPort target
+	, "--publicKey", "test_key.pub"
+	, "--privateKey", "test_key"
+	, "schedule"
+	, "--scheduler", scheduler
+	, "--script", script
+	, "--logFile", "test_job.log"
+	, "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
+  ] ++ extraArgs
+
+shouldExitWith :: [String] -> ExitCode -> IO()
+shouldExitWith args expectedCode = do
+  (actualCode, _, _) <- runHpci args
+  actualCode `shouldBe` expectedCode
+
 integrationSpec :: Spec
 integrationSpec = describe "Docker Integration Tests" $ do
   before setupContainerTargets $ do
 
-    it "succeeds for a normal slurm job" $ \(slurm, _pbs) -> do
+    context "Normal Job Execution" $ do
+      it "succeeds for a normal slurm job" $ \(slurm, _pbs) -> do
+        baseScheduleArgs slurm "slurm" "ci/test_job.slurm" [] `shouldExitWith` ExitSuccess
 
-      let cliArgs = [ "--user", targetUser slurm
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort slurm
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "slurm"
-			           , "--script", "ci/test_job.slurm"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
+      it "succeeds for a normal pbs job" $ \(_slurm, pbs) -> do
+        baseScheduleArgs pbs "pbs" "ci/test_job.pbs" [] `shouldExitWith` ExitSuccess
 
-      (jobExitCode, _, _) <- runHpci cliArgs
+    context "Submission Error (Wrong Partition/Queue)" $ do
+      it "crashes when there is a slurm submission error (wrong partition)" $ \(slurm, _pbs) -> do
+        baseScheduleArgs slurm "slurm" "ci/test_fail.slurm" [] `shouldExitWith` (ExitFailure 1)
 
-      jobExitCode `shouldBe` ExitSuccess
+      it "crashes when there is a pbs job submission error (wrong queue)" $ \(_slurm, pbs) -> do
+        baseScheduleArgs pbs "pbs" "ci/test_fail.pbs" [] `shouldExitWith` (ExitFailure 1)
 
-    it "succeeds for a normal pbs job" $ \(_slurm, pbs) -> do
+    context "Submission Error (Non-zero Exit)" $ do
+      it "crashes when there is a slurm submission error (non-zero exit)" $ \(slurm, _pbs) -> do
+        baseScheduleArgs slurm "slurm" "ci/test_exit.slurm" [] `shouldExitWith` (ExitFailure 7)
 
-      let cliArgs = [ "--user", targetUser pbs
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort pbs
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "pbs"
-			           , "--script", "ci/test_job.pbs"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
+      it "crashes when there is a pbs job submission error (non-zero exit)" $ \(_slurm, pbs) -> do
+        baseScheduleArgs pbs "pbs" "ci/test_exit.pbs" [] `shouldExitWith` (ExitFailure 7)
 
-      (jobExitCode, _, _) <- runHpci cliArgs
+    context "Scheduler Argument Overrides" $ do
+      it "succeeds when a '--scheduler-arg' successfully overrides a slurm submission error" $ \(slurm, _pbs) -> do
+        let extra = ["--scheduler-arg", "--partition=all", "--scheduler-arg", "--job-name=testjob"]
+        baseScheduleArgs slurm "slurm" "ci/test_fail.slurm" extra `shouldExitWith` ExitSuccess
 
-      jobExitCode `shouldBe` ExitSuccess
+      it "succeeds when a '--scheduler-arg' overrides a pbs job submission error" $ \(_slurm, pbs) -> do
+        let extra = ["--scheduler-arg", "-q workq", "--scheduler-arg", "-N testjob"]
+        baseScheduleArgs pbs "pbs" "ci/test_fail.pbs" extra `shouldExitWith` ExitSuccess
 
-    it "crashes when there is a slurm submission error (wrong partition)" $ \(slurm, _pbs) -> do
-      let cliArgs = [ "--user", targetUser slurm
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort slurm
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "slurm"
-			           , "--script", "ci/test_fail.slurm"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
+    context "Scheduler Argument Escaping" $ do
+      it "escapes tricky characters in slurm '--scheduler-arg'" $ \(slurm, _pbs) -> do
+        let extra = ["--scheduler-arg", "--job-name='Build&Test'"]
+        baseScheduleArgs slurm "slurm" "ci/test_job.slurm" extra `shouldExitWith` ExitSuccess
 
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitFailure 1
-
-    it "crashes when there is a slurm submission error (non-zero exit)" $ \(slurm, _pbs) -> do
-      let cliArgs = [ "--user", targetUser slurm
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort slurm
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "slurm"
-			           , "--script", "ci/test_exit.slurm"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitFailure 7
-
-    it "crashes when there is a pbs job submission error (wrong queue)" $ \(_slurm, pbs) -> do
-      let cliArgs = [ "--user", targetUser pbs
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort pbs
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "pbs"
-			           , "--script", "ci/test_fail.pbs"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitFailure 1
-
-    it "crashes when there is a pbs job submission error (non-zero exit)" $ \(_slurm, pbs) -> do
-      let cliArgs = [ "--user", targetUser pbs
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort pbs
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "pbs"
-			           , "--script", "ci/test_exit.pbs"
-			           , "--logFile", "test_job.log"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitFailure 7
-
-    it "succeeds when a '--scheduler-arg' successfully overrides a slurm submission error" $ \(slurm, _pbs) -> do
-      let cliArgs = [ "--user", targetUser slurm
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort slurm
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "slurm"
-			           , "--script", "ci/test_fail.slurm"
-			           , "--logFile", "test_job.log"
-                 , "--scheduler-arg", "--partition=all"
-                 , "--scheduler-arg", "--job-name=testjob"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitSuccess
-
-    it "succeeds when a '--scheduler-arg' overrides a pbs job submission error" $ \(_slurm, pbs) -> do
-      let cliArgs = [ "--user", targetUser pbs
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort pbs
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "pbs"
-			           , "--script", "ci/test_fail.pbs"
-			           , "--logFile", "test_job.log"
-                 , "--scheduler-arg", "-q workq"
-                 , "--scheduler-arg", "-N testjob"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitSuccess
-
-    it "escapes tricky characters in slurm '--scheduler-arg'" $ \(slurm, _pbs) -> do
-      let cliArgs = [ "--user", targetUser slurm
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort slurm
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "slurm"
-			           , "--script", "ci/test_job.slurm"
-			           , "--logFile", "test_job.log"
-                 , "--scheduler-arg", "--job-name='Build&Test'"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitSuccess
-
-    it "escapes tricky characters in pbs '--scheduler-arg'" $ \(_slurm, pbs) -> do
-      let cliArgs = [ "--user", targetUser pbs
-			           , "--host", "127.0.0.1"
-			           , "--port", targetPort pbs
-			           , "--publicKey", "test_key.pub"
-			           , "--privateKey", "test_key"
-			           , "schedule"
-			           , "--scheduler", "pbs"
-			           , "--script", "ci/test_job.pbs"
-			           , "--logFile", "test_job.log"
-                 , "--scheduler-arg", "-l 'walltime=01:30:00'"
-			           , "-c", "TEST_VAR1=success,TEST_VAR2=double_success"
-                ]
-
-      (jobExitCode, _, _) <- runHpci cliArgs
-
-      jobExitCode `shouldBe` ExitSuccess
+      it "escapes tricky characters in pbs '--scheduler-arg'" $ \(_slurm, pbs) -> do
+        let extra = ["--scheduler-arg", "-l 'walltime=01:30:00'"]
+        baseScheduleArgs pbs "pbs" "ci/test_job.pbs" extra `shouldExitWith` ExitSuccess

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -2,11 +2,7 @@
 
 module Integrations (integrationSpec) where
 
-import Control.Monad.IO.Class (liftIO)
-import Data.Text (pack)
 import Data.List (isInfixOf)
-import qualified Data.Text.Lazy as LazyText
-import System.Directory (makeAbsolute)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
 import Test.Hspec
@@ -140,7 +136,30 @@ integrationSpec = describe "Docker Integration Tests" $ do
         exitCode `shouldNotBe` ExitSuccess
         (stdout ++ stderr) `shouldSatisfy` ("Network connection timed" `isInfixOf`)
 
--- user error
--- scheduler
--- logfile
--- script
+      it "prints a verbose authentication error when user is incorrect" $ \(slurm, _) -> do
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        let badKeyArgs = replaceArg "--user" "wrongUser" baseArgs
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` (renderSshError AUTHENTICATION_FAILED `isInfixOf`)
+
+      it "prints a verbose error when logfile is missing on HPC" $ \(slurm, _) -> do
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        let badKeyArgs = replaceArg "--logFile" "fake_log.log" baseArgs
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` (renderSshError SCP_PROTOCOL `isInfixOf`)
+
+      it "prints a verbose error when script is missing on CI runner" $ \(slurm, _) -> do
+        let badKeyArgs = baseScheduleArgs slurm "slurm" "ci/fake_job.slurm" []
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` ("Local File Missing" `isInfixOf`)

--- a/test/Integrations.hs
+++ b/test/Integrations.hs
@@ -104,17 +104,29 @@ integrationSpec = describe "Docker Integration Tests" $ do
         exitCode `shouldNotBe` ExitSuccess
         (stdout ++ stderr) `shouldSatisfy` (renderSshError FILE `isInfixOf`)
 
-      it "prints a verbose AUTHENTICATION_FAILED error when SSH keys are invalid" $ \(slurm, _) -> do
+      it "prints a verbose AUTHENTICATION_FAILED error when public SSH key is invalid" $ \(slurm, _) -> do
         let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
 
         -- key file exists but is not the correct key
-        let badKeyArgs = replaceArg "--publicKey" "ci/fake_key.pub" $ replaceArg "--privateKey" "ci/fake_key" baseArgs
+        let badKeyArgs = replaceArg "--publicKey" "ci/fake_key.pub" baseArgs
 
         (exitCode, stdout, stderr) <- runHpci badKeyArgs
 
         exitCode `shouldNotBe` ExitSuccess
         (stdout ++ stderr) `shouldSatisfy` (renderSshError AUTHENTICATION_FAILED `isInfixOf`)
 
+      it "prints a verbose PUBLICKEY_UNVERIFIED error when SSH private key is invalid" $ \(slurm, _) -> do
+        let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
+
+        -- key file exists but is not the correct key
+        let badKeyArgs = replaceArg "--privateKey" "ci/fake_key" baseArgs
+
+        (exitCode, stdout, stderr) <- runHpci badKeyArgs
+
+        exitCode `shouldNotBe` ExitSuccess
+        (stdout ++ stderr) `shouldSatisfy` (renderSshError PUBLICKEY_UNVERIFIED `isInfixOf`)
+
+    context "Network Error messages" $ do
       it "prints a verbose network error when port is incorrect" $ \(slurm, _) -> do
         let baseArgs = baseScheduleArgs slurm "slurm" "ci/test_job.slurm" []
 

--- a/test/Specs.hs
+++ b/test/Specs.hs
@@ -5,8 +5,8 @@ module Specs (retrySpec) where
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Data.IORef
 import Control.Exception
-import Data.Typeable
 import Control.Retry
+import Network.SSH.Client.LibSSH2.Errors (ErrorCode(..))
 
 import Helpers (
   sessionRetry
@@ -15,9 +15,6 @@ import Helpers (
 -- Test retry functionality
 data MockSession = MockSession deriving (Show, Eq)
 
-data MockConnectionError = MockConnectionError deriving (Show, Typeable)
-instance Exception MockConnectionError
-
 mockConnect :: IORef Int -> IO MockSession
 mockConnect attemptCounter = do
   attempt <- readIORef attemptCounter
@@ -25,7 +22,7 @@ mockConnect attemptCounter = do
   putStrLn $ "Mock connection: trying attempt #" <> show (attempt + 1)
 
   if attempt < 2
-    then throwIO MockConnectionError
+    then throwIO TIMEOUT
     else return MockSession
 
 retrySpec :: RetryPolicy -> Spec


### PR DESCRIPTION
Wraps the LibSSH2 error messages in more verbose and helpful error messages.

Adds many more tests to verify error messages work as expected.

Refactors tests to be more DRY.

Resolves #41 